### PR TITLE
feat: add role context and client-side data fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ backend/.venv/
 fe-test/node_modules/
 frontend/node_modules/
 frontend/.next/
+frontend/tsconfig.tsbuildinfo
 
 # Environment files
 .env

--- a/frontend/app/requests/page.tsx
+++ b/frontend/app/requests/page.tsx
@@ -1,4 +1,9 @@
+"use client";
+
 import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+
+import { ApiError, useApiClient } from "../../lib/api";
 
 type RequestRow = {
   id: string;
@@ -9,6 +14,10 @@ type RequestRow = {
   created_at: string;
 };
 
+type RequestsResponse = {
+  items?: RequestRow[];
+};
+
 const columns = [
   { key: "title", label: "Title" },
   { key: "feature_name", label: "Feature" },
@@ -16,26 +25,20 @@ const columns = [
   { key: "assigned_writer_id", label: "Writer" }
 ];
 
-async function fetchRequests(): Promise<RequestRow[]> {
-  const base = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8000";
-  const role = process.env.NEXT_PUBLIC_API_ROLE ?? "designer";
-  const userId = process.env.NEXT_PUBLIC_API_USER_ID ?? "designer-1";
-  const res = await fetch(`${base}/v1/requests`, {
-    headers: {
-      "X-User-Role": role,
-      "X-User-Id": userId,
-    },
-    cache: "no-store",
-  });
-  if (!res.ok) {
-    throw new Error(`Failed to load requests (${res.status})`);
-  }
-  const data = await res.json();
-  return (data.items ?? []) as RequestRow[];
-}
+export default function RequestsPage() {
+  const api = useApiClient();
 
-export default async function RequestsPage() {
-  const rows = await fetchRequests();
+  const { data, isLoading, isError, error } = useQuery<RequestRow[], ApiError>({
+    queryKey: ["requests", "list"],
+    queryFn: async () => {
+      const response = await api.get<RequestsResponse>("/v1/requests");
+      return response.items ?? [];
+    },
+  });
+
+  const rows = data ?? [];
+  const errorMessage = error?.message ?? "Unable to load requests.";
+
   return (
     <section className="space-y-6">
       <header className="flex items-center justify-between">
@@ -51,35 +54,46 @@ export default async function RequestsPage() {
         </Link>
       </header>
       <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-        <table className="min-w-full divide-y divide-slate-200 text-sm">
-          <thead className="bg-slate-50">
-            <tr>
-              {columns.map((column) => (
-                <th key={column.key} className="px-4 py-3 text-left font-semibold text-slate-600">
-                  {column.label}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-slate-100">
-            {rows.map((row) => (
-              <tr key={row.id} className="hover:bg-slate-50">
-                <td className="px-4 py-3">
-                  <Link href={`/requests/${row.id}`} className="text-primary-600">
-                    {row.title}
-                  </Link>
-                </td>
-                <td className="px-4 py-3 text-slate-600">{row.feature_name}</td>
-                <td className="px-4 py-3">
-                  <span className="rounded-full bg-primary-50 px-3 py-1 text-xs font-semibold text-primary-600">
-                    {row.status}
-                  </span>
-                </td>
-                <td className="px-4 py-3 text-slate-600">{row.assigned_writer_id ?? "Unassigned"}</td>
+        {isLoading && (
+          <div className="px-4 py-6 text-sm text-slate-500">Loading requests…</div>
+        )}
+        {isError && !isLoading && (
+          <div className="px-4 py-6 text-sm text-red-600">{errorMessage}</div>
+        )}
+        {!isLoading && !isError && rows.length === 0 && (
+          <div className="px-4 py-6 text-sm text-slate-500">No requests have been created yet.</div>
+        )}
+        {!isLoading && !isError && rows.length > 0 && (
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-50">
+              <tr>
+                {columns.map((column) => (
+                  <th key={column.key} className="px-4 py-3 text-left font-semibold text-slate-600">
+                    {column.label}
+                  </th>
+                ))}
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {rows.map((row) => (
+                <tr key={row.id} className="hover:bg-slate-50">
+                  <td className="px-4 py-3">
+                    <Link href={`/requests/${row.id}`} className="text-primary-600">
+                      {row.title}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-slate-600">{row.feature_name}</td>
+                  <td className="px-4 py-3">
+                    <span className="rounded-full bg-primary-50 px-3 py-1 text-xs font-semibold text-primary-600">
+                      {row.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-slate-600">{row.assigned_writer_id ?? "Unassigned"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
       </div>
     </section>
   );

--- a/frontend/app/workspace/page.tsx
+++ b/frontend/app/workspace/page.tsx
@@ -1,3 +1,10 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { ApiError, useApiClient } from "../../lib/api";
+
 type RetrievalItem = {
   sid: string;
   en_line: string;
@@ -11,49 +18,88 @@ type RequestSummary = {
   feature_name: string;
   status: string;
   constraints_json?: Record<string, string>;
+  context_description?: string;
 };
 
-async function fetchWorkspaceData(): Promise<{ request: RequestSummary | null; references: RetrievalItem[] }> {
-  const base = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8000";
-  const role = process.env.NEXT_PUBLIC_API_ROLE ?? "writer";
-  const userId = process.env.NEXT_PUBLIC_API_USER_ID ?? "writer-1";
-  const headers = {
-    "X-User-Role": role,
-    "X-User-Id": userId,
-  };
-  const listRes = await fetch(`${base}/v1/requests`, { headers, cache: "no-store" });
-  if (!listRes.ok) {
-    return { request: null, references: [] };
-  }
-  const listJson = await listRes.json();
-  const first = (listJson.items ?? [])[0];
-  if (!first) {
-    return { request: null, references: [] };
-  }
-  const detailRes = await fetch(`${base}/v1/requests/${first.id}`, { headers, cache: "no-store" });
-  const detailJson = detailRes.ok ? await detailRes.json() : first;
-  const filters = detailJson.constraints_json ?? {};
-  const retrieveRes = await fetch(`${base}/v1/retrieve`, {
-    method: "POST",
-    headers: { ...headers, "Content-Type": "application/json" },
-    body: JSON.stringify({ query: detailJson.context_description ?? "", filters, topK: 3 }),
-    cache: "no-store",
-  });
-  const retrieveJson = retrieveRes.ok ? await retrieveRes.json() : { items: [] };
-  return { request: detailJson as RequestSummary, references: retrieveJson.items ?? [] };
-}
+type RequestsListResponse = {
+  items?: RequestSummary[];
+};
 
-export default async function WorkspacePage() {
-  const { request, references } = await fetchWorkspaceData();
+type RetrievalResponse = {
+  items?: RetrievalItem[];
+};
+
+type WorkspaceData = {
+  request: RequestSummary | null;
+  references: RetrievalItem[];
+  warnings: string[];
+};
+
+const emptyWorkspace: WorkspaceData = {
+  request: null,
+  references: [],
+  warnings: [],
+};
+
+export default function WorkspacePage() {
+  const api = useApiClient();
+
+  const { data, isLoading, isError, error } = useQuery<WorkspaceData, ApiError>({
+    queryKey: ["workspace", "current"],
+    queryFn: async () => {
+      const warnings: string[] = [];
+      const listResponse = await api.get<RequestsListResponse>("/v1/requests");
+      const first = listResponse.items?.[0];
+      if (!first) {
+        return { request: null, references: [], warnings: [] };
+      }
+
+      let requestDetail: RequestSummary = first;
+      try {
+        requestDetail = await api.get<RequestSummary>(`/v1/requests/${first.id}`);
+      } catch (detailError) {
+        const message = detailError instanceof ApiError ? detailError.message : "Failed to load request details.";
+        warnings.push(message);
+      }
+
+      let references: RetrievalItem[] = [];
+      try {
+        const payload = {
+          query: requestDetail.context_description ?? "",
+          filters: requestDetail.constraints_json ?? {},
+          topK: 3,
+        };
+        const retrievalResponse = await api.post<RetrievalResponse>("/v1/retrieve", {
+          body: JSON.stringify(payload),
+        });
+        references = retrievalResponse.items ?? [];
+      } catch (retrieveError) {
+        const message =
+          retrieveError instanceof ApiError ? retrieveError.message : "Failed to load retrieval candidates.";
+        warnings.push(message);
+      }
+
+      return {
+        request: requestDetail,
+        references,
+        warnings,
+      };
+    },
+  });
+
+  const workspace = data ?? emptyWorkspace;
+  const topWarning = useMemo(() => workspace.warnings[0], [workspace.warnings]);
+  const errorMessage = error?.message ?? "Unable to load workspace.";
+
   return (
     <section className="space-y-6">
       <header className="flex flex-wrap items-center justify-between gap-4">
         <div className="space-y-2">
           <p className="text-xs font-semibold uppercase tracking-wide text-primary-600">
-            {request ? request.id : "No request loaded"}
+            {workspace.request ? workspace.request.id : "No request loaded"}
           </p>
           <h1 className="text-2xl font-semibold text-slate-900">
-            {request ? request.title : "Select a request"}
+            {workspace.request ? workspace.request.title : "Select a request"}
           </h1>
           <p className="text-sm text-slate-600">
             Compare references from the retrieval API and promote the best draft for approval.
@@ -68,11 +114,22 @@ export default async function WorkspacePage() {
           </button>
         </div>
       </header>
+
+      {isLoading && <div className="rounded-md border border-dashed border-slate-300 bg-white/50 p-4 text-sm text-slate-500">Loading workspace…</div>}
+      {isError && !isLoading && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">{errorMessage}</div>
+      )}
+      {!isLoading && !isError && topWarning && (
+        <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">{topWarning}</div>
+      )}
+
       <div className="grid gap-4 md:grid-cols-3">
-        {references.length === 0 && (
-          <p className="col-span-3 text-sm text-slate-500">No retrieval candidates available. Trigger ingest to seed data.</p>
+        {workspace.references.length === 0 && !isLoading && !isError && (
+          <p className="col-span-3 text-sm text-slate-500">
+            No retrieval candidates available. Trigger ingest to seed data.
+          </p>
         )}
-        {references.map((item) => (
+        {workspace.references.map((item) => (
           <article key={item.sid} className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <header className="flex items-center justify-between text-xs text-slate-500">
               <span className="font-semibold uppercase">{item.sid}</span>
@@ -95,10 +152,10 @@ export default async function WorkspacePage() {
         <article className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
           <h2 className="text-sm font-semibold text-slate-900">RAG References</h2>
           <ul className="mt-3 space-y-2 text-sm text-slate-600">
-            {references.slice(0, 3).map((item) => (
+            {workspace.references.slice(0, 3).map((item) => (
               <li key={item.sid}>{item.en_line}</li>
             ))}
-            {references.length === 0 && <li>No references yet.</li>}
+            {workspace.references.length === 0 && <li>No references yet.</li>}
           </ul>
         </article>
       </section>

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -3,7 +3,11 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import clsx from "classnames";
+import { useMemo, useState } from "react";
 import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { RoleProvider, useRole } from "./role-context";
 
 const NAV_LINKS = [
   { href: "/", label: "Overview" },
@@ -13,7 +17,28 @@ const NAV_LINKS = [
 ];
 
 export function AppShell({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <RoleProvider>
+      <QueryClientProvider client={queryClient}>
+        <AppShellInner>{children}</AppShellInner>
+      </QueryClientProvider>
+    </RoleProvider>
+  );
+}
+
+function AppShellInner({ children }: { children: ReactNode }) {
   const pathname = usePathname();
+  const { role, userId, toggleRole } = useRole();
+
+  const roleDisplay = useMemo(() => {
+    if (!role) {
+      return "Unknown";
+    }
+    return `${role.charAt(0).toUpperCase()}${role.slice(1)}`;
+  }, [role]);
+
   return (
     <div className="min-h-screen flex flex-col">
       <header className="border-b bg-white">
@@ -25,8 +50,14 @@ export function AppShell({ children }: { children: ReactNode }) {
             <span className="text-sm text-slate-500">Day 3 workspace shell</span>
           </div>
           <div className="flex items-center gap-2 text-sm">
-            <span className="rounded-full bg-slate-100 px-3 py-1 text-slate-600">Designer</span>
-            <button className="rounded-md border border-slate-200 px-3 py-1 text-slate-600 hover:bg-slate-100">
+            <span className="rounded-full bg-slate-100 px-3 py-1 text-slate-600">
+              {roleDisplay} · {userId}
+            </span>
+            <button
+              type="button"
+              onClick={toggleRole}
+              className="rounded-md border border-slate-200 px-3 py-1 text-slate-600 transition-colors hover:bg-slate-100"
+            >
               Switch Role
             </button>
           </div>

--- a/frontend/components/role-context.tsx
+++ b/frontend/components/role-context.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+type RoleIdentity = {
+  role: string;
+  userId: string;
+};
+
+type RoleContextValue = RoleIdentity & {
+  toggleRole: () => void;
+  setRole: (role: string, userId?: string) => void;
+  setUserId: (userId: string) => void;
+};
+
+const DEFAULT_IDENTITIES: RoleIdentity[] = [
+  { role: "designer", userId: "designer-1" },
+  { role: "writer", userId: "writer-1" },
+];
+
+const FALLBACK_USER_BY_ROLE = DEFAULT_IDENTITIES.reduce<Record<string, string>>((acc, identity) => {
+  acc[identity.role] = identity.userId;
+  return acc;
+}, {});
+
+const RoleContext = createContext<RoleContextValue | undefined>(undefined);
+
+const resolveInitialIdentity = (): RoleIdentity => {
+  const envRole = process.env.NEXT_PUBLIC_API_ROLE;
+  const envUserId = process.env.NEXT_PUBLIC_API_USER_ID;
+  if (envRole) {
+    return {
+      role: envRole,
+      userId: envUserId ?? FALLBACK_USER_BY_ROLE[envRole] ?? `${envRole}-1`,
+    };
+  }
+  return DEFAULT_IDENTITIES[0];
+};
+
+export function RoleProvider({ children }: { children: ReactNode }) {
+  const [identity, setIdentity] = useState<RoleIdentity>(() => resolveInitialIdentity());
+
+  const toggleRole = useCallback(() => {
+    setIdentity((current) => {
+      const index = DEFAULT_IDENTITIES.findIndex((identityItem) => identityItem.role === current.role);
+      if (index === -1) {
+        return DEFAULT_IDENTITIES[0];
+      }
+      const nextIndex = (index + 1) % DEFAULT_IDENTITIES.length;
+      return DEFAULT_IDENTITIES[nextIndex];
+    });
+  }, []);
+
+  const setRole = useCallback((role: string, userId?: string) => {
+    setIdentity((current) => ({
+      role,
+      userId: userId ?? (role === current.role ? current.userId : FALLBACK_USER_BY_ROLE[role] ?? `${role}-1`),
+    }));
+  }, []);
+
+  const setUserId = useCallback((userId: string) => {
+    setIdentity((current) => ({ ...current, userId }));
+  }, []);
+
+  const value = useMemo<RoleContextValue>(() => ({
+    role: identity.role,
+    userId: identity.userId,
+    toggleRole,
+    setRole,
+    setUserId,
+  }), [identity.role, identity.userId, setRole, setUserId, toggleRole]);
+
+  return <RoleContext.Provider value={value}>{children}</RoleContext.Provider>;
+}
+
+export function useRole() {
+  const context = useContext(RoleContext);
+  if (!context) {
+    throw new Error("useRole must be used within a RoleProvider");
+  }
+  return context;
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,108 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+
+import { useRole } from "../components/role-context";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8000";
+
+export class ApiError extends Error {
+  status: number;
+
+  details?: unknown;
+
+  constructor(message: string, status: number, details?: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.details = details;
+  }
+}
+
+async function buildApiError(response: Response): Promise<ApiError> {
+  const status = response.status;
+  let message = response.statusText || `Request failed with status ${status}`;
+  let details: unknown;
+
+  try {
+    const data = await response.clone().json();
+    details = data;
+    if (typeof data === "object" && data !== null) {
+      const potentialMessage =
+        (data as Record<string, unknown>).message ??
+        (data as Record<string, unknown>).detail ??
+        (data as Record<string, unknown>).error;
+      if (typeof potentialMessage === "string" && potentialMessage.trim().length > 0) {
+        message = potentialMessage;
+      }
+    }
+  } catch {
+    try {
+      const text = await response.text();
+      if (text.trim().length > 0) {
+        message = text;
+      }
+    } catch {
+      // ignore secondary parsing errors
+    }
+  }
+
+  return new ApiError(message, status, details);
+}
+
+export type ApiClient = {
+  request: <T>(path: string, init?: RequestInit) => Promise<T>;
+  get: <T>(path: string, init?: RequestInit) => Promise<T>;
+  post: <T>(path: string, init?: RequestInit) => Promise<T>;
+};
+
+const ensureHeaders = (init?: RequestInit, role?: string, userId?: string) => {
+  const headers = new Headers(init?.headers ?? {});
+  if (role) {
+    headers.set("X-User-Role", role);
+  }
+  if (userId) {
+    headers.set("X-User-Id", userId);
+  }
+  return headers;
+};
+
+export function useApiClient(): ApiClient {
+  const { role, userId } = useRole();
+
+  const request = useCallback(
+    async <T>(path: string, init: RequestInit = {}) => {
+      const headers = ensureHeaders(init, role, userId);
+      if (init.body && !(init.body instanceof FormData) && !headers.has("Content-Type")) {
+        headers.set("Content-Type", "application/json");
+      }
+
+      const response = await fetch(`${API_BASE}${path}`, {
+        ...init,
+        method: init.method ?? "GET",
+        headers,
+        cache: "no-store",
+      });
+
+      if (!response.ok) {
+        throw await buildApiError(response);
+      }
+
+      const contentType = response.headers.get("content-type");
+      if (contentType?.includes("application/json")) {
+        return (await response.json()) as T;
+      }
+      return (await response.text()) as T;
+    },
+    [role, userId]
+  );
+
+  return useMemo<ApiClient>(
+    () => ({
+      request,
+      get: <T>(path: string, init?: RequestInit) => request<T>(path, { ...init, method: "GET" }),
+      post: <T>(path: string, init?: RequestInit) => request<T>(path, { ...init, method: "POST" }),
+    }),
+    [request]
+  );
+}


### PR DESCRIPTION
## Summary
- add a shared role context/provider and hook it into the shell with a toggleable Switch Role button
- introduce a reusable API client hook that injects role headers and normalizes error handling
- convert the requests and workspace pages to client components backed by React Query with loading and error states

## Testing
- pnpm exec tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e61fb6e2b08324b6c9810c881dab5c