### PR TITLE
feat: add request creation and detail pages

### DIFF
--- a/frontend/app/requests/[id]/RequestDetailView.tsx
+++ b/frontend/app/requests/[id]/RequestDetailView.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useMemo } from "react";
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import clsx from "classnames";
+
+import { ApiError, useApiClient } from "../../../lib/api";
+
+type RequestDetail = {
+  id: string;
+  title: string;
+  feature_name: string;
+  status: string;
+  assigned_writer_id: string | null;
+  created_at: string;
+  updated_at: string;
+  draft_count: number;
+  context_description?: string | null;
+  tone?: string | null;
+  style_preferences?: string | null;
+  constraints_json?: Record<string, unknown> | null;
+};
+
+type Comment = {
+  id: string;
+  request_id: string;
+  draft_version_id: string | null;
+  author_id: string;
+  body: string;
+  status: "open" | "resolved";
+  created_at: string;
+  resolved_at: string | null;
+};
+
+type CommentsResponse = {
+  items?: Comment[];
+};
+
+const statusColors: Record<string, string> = {
+  drafting: "bg-slate-100 text-slate-700",
+  in_review: "bg-amber-100 text-amber-800",
+  approved: "bg-emerald-100 text-emerald-700",
+  rejected: "bg-rose-100 text-rose-700",
+};
+
+function formatDate(value: string) {
+  try {
+    return new Intl.DateTimeFormat("en", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(value));
+  } catch (error) {
+    console.error("Failed to format date", error);
+    return value;
+  }
+}
+
+function formatStatus(value: string) {
+  return value
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function formatConstraintValue(value: unknown) {
+  if (value === null || value === undefined) {
+    return "—";
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : "—";
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    console.error("Failed to stringify constraint value", error);
+    return String(value);
+  }
+}
+
+export function RequestDetailView({ requestId }: { requestId: string }) {
+  const api = useApiClient();
+
+  const {
+    data: detail,
+    isLoading: isLoadingDetail,
+    isError: isDetailError,
+    error: detailError,
+  } = useQuery<RequestDetail, ApiError>({
+    queryKey: ["requests", requestId, "detail"],
+    queryFn: async () => api.get<RequestDetail>(`/v1/requests/${requestId}`),
+  });
+
+  const {
+    data: commentsResponse,
+    isLoading: isLoadingComments,
+    isError: isCommentsError,
+    error: commentsError,
+  } = useQuery<CommentsResponse, ApiError>({
+    queryKey: ["requests", requestId, "comments"],
+    queryFn: async () => api.get<CommentsResponse>(`/v1/requests/${requestId}/comments`),
+    enabled: Boolean(requestId),
+  });
+
+  const comments = commentsResponse?.items ?? [];
+  const openComments = useMemo(() => comments.filter((comment) => comment.status === "open"), [comments]);
+  const resolvedComments = useMemo(
+    () => comments.filter((comment) => comment.status === "resolved"),
+    [comments]
+  );
+  const latestComments = useMemo(() => comments.slice(-3).reverse(), [comments]);
+
+  const detailErrorMessage = detailError?.message ?? "Unable to load request.";
+  const commentsErrorMessage = commentsError?.message ?? "Unable to load comments.";
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-primary-600">Request</p>
+          <h1 className="text-2xl font-semibold text-slate-900">
+            {detail ? detail.title : isLoadingDetail ? "Loading…" : "Request not found"}
+          </h1>
+          {detail && (
+            <p className="text-sm text-slate-600">
+              Feature {detail.feature_name} · Created {formatDate(detail.created_at)}
+            </p>
+          )}
+        </div>
+        <Link href="/requests" className="text-sm text-primary-600 hover:text-primary-500">
+          Back to queue
+        </Link>
+      </header>
+
+      {isDetailError && !isLoadingDetail && (
+        <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {detailErrorMessage}
+        </div>
+      )}
+
+      {detail && (
+        <div className="space-y-6">
+          <div className="flex flex-wrap items-center gap-3 text-sm text-slate-600">
+            <span
+              className={clsx(
+                "inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold",
+                statusColors[detail.status] ?? "bg-slate-100 text-slate-700"
+              )}
+            >
+              {formatStatus(detail.status)}
+            </span>
+            {detail.assigned_writer_id && (
+              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-600">
+                Assigned to {detail.assigned_writer_id}
+              </span>
+            )}
+            <span className="text-xs text-slate-500">Last updated {formatDate(detail.updated_at)}</span>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-3">
+            <article className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h2 className="text-sm font-semibold text-slate-900">Draft progress</h2>
+              <p className="mt-3 text-3xl font-semibold text-slate-900">{detail.draft_count}</p>
+              <p className="mt-2 text-sm text-slate-600">
+                {detail.draft_count === 0
+                  ? "No drafts submitted yet."
+                  : detail.draft_count === 1
+                  ? "One draft available for review."
+                  : `${detail.draft_count} drafts captured to date.`}
+              </p>
+            </article>
+            <article className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h2 className="text-sm font-semibold text-slate-900">Approval status</h2>
+              <p className="mt-3 text-lg font-semibold text-slate-900">{formatStatus(detail.status)}</p>
+              <p className="mt-2 text-sm text-slate-600">
+                {detail.status === "approved"
+                  ? "Approved and ready for export."
+                  : detail.status === "rejected"
+                  ? "Latest approval decision rejected the request."
+                  : "Awaiting approval decision."}
+              </p>
+            </article>
+            <article className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h2 className="text-sm font-semibold text-slate-900">Comment summary</h2>
+              {isLoadingComments && <p className="mt-3 text-sm text-slate-500">Loading comments…</p>}
+              {isCommentsError && !isLoadingComments && (
+                <p className="mt-3 text-sm text-red-600">{commentsErrorMessage}</p>
+              )}
+              {!isLoadingComments && !isCommentsError && (
+                <div className="mt-3 space-y-1 text-sm text-slate-600">
+                  <p>
+                    <span className="font-semibold text-slate-900">{openComments.length}</span> open
+                  </p>
+                  <p>
+                    <span className="font-semibold text-slate-900">{resolvedComments.length}</span> resolved
+                  </p>
+                </div>
+              )}
+            </article>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+              <h2 className="text-sm font-semibold text-slate-900">Context</h2>
+              <div className="mt-3 space-y-3 text-sm text-slate-700">
+                <div>
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Description</h3>
+                  <p className="mt-1 text-slate-700">
+                    {detail.context_description && detail.context_description.trim().length > 0
+                      ? detail.context_description
+                      : "No additional context provided."}
+                  </p>
+                </div>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <div>
+                    <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Tone</h3>
+                    <p className="mt-1 text-slate-700">{detail.tone?.trim() || "—"}</p>
+                  </div>
+                  <div>
+                    <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Style</h3>
+                    <p className="mt-1 text-slate-700">{detail.style_preferences?.trim() || "—"}</p>
+                  </div>
+                </div>
+              </div>
+            </section>
+            <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+              <h2 className="text-sm font-semibold text-slate-900">Constraints</h2>
+              {detail.constraints_json && Object.keys(detail.constraints_json).length > 0 ? (
+                <dl className="mt-3 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+                  {Object.entries(detail.constraints_json).map(([key, value]) => (
+                    <div key={key} className="rounded-lg bg-slate-50 px-3 py-2">
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">{key}</dt>
+                      <dd className="mt-1 text-slate-700">{formatConstraintValue(value)}</dd>
+                    </div>
+                  ))}
+                </dl>
+              ) : (
+                <p className="mt-3 text-sm text-slate-600">No constraints provided.</p>
+              )}
+            </section>
+          </div>
+
+          <section className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h2 className="text-sm font-semibold text-slate-900">Recent comments</h2>
+              {comments.length > 3 && (
+                <span className="text-xs text-slate-500">Showing latest {latestComments.length} of {comments.length}</span>
+              )}
+            </div>
+            {isLoadingComments && <p className="text-sm text-slate-500">Loading comments…</p>}
+            {isCommentsError && !isLoadingComments && (
+              <p className="text-sm text-red-600">{commentsErrorMessage}</p>
+            )}
+            {!isLoadingComments && !isCommentsError && comments.length === 0 && (
+              <p className="text-sm text-slate-600">No comments yet.</p>
+            )}
+            {!isLoadingComments && !isCommentsError && latestComments.length > 0 && (
+              <ul className="space-y-3">
+                {latestComments.map((comment) => (
+                  <li key={comment.id} className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                    <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-slate-500">
+                      <span className="font-semibold uppercase tracking-wide">{comment.author_id}</span>
+                      <span>{formatDate(comment.created_at)}</span>
+                    </div>
+                    <p className="mt-3 text-sm text-slate-700">{comment.body}</p>
+                    <span
+                      className={clsx(
+                        "mt-3 inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold",
+                        comment.status === "resolved"
+                          ? "bg-emerald-100 text-emerald-700"
+                          : "bg-amber-100 text-amber-800"
+                      )}
+                    >
+                      {comment.status === "resolved" ? "Resolved" : "Open"}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/app/requests/[id]/page.tsx
+++ b/frontend/app/requests/[id]/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+import { RequestDetailView } from "./RequestDetailView";
+
+export const metadata: Metadata = {
+  title: "Request Details · UX Writer Assistant",
+  description: "Review draft progress, approvals, and feedback for a UX copy request.",
+};
+
+export default function RequestDetailPage({ params }: { params: { id: string } }) {
+  return <RequestDetailView requestId={params.id} />;
+}

--- a/frontend/app/requests/new/NewRequestForm.tsx
+++ b/frontend/app/requests/new/NewRequestForm.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import type { ChangeEvent, FormEvent } from "react";
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import { ApiError, useApiClient } from "../../../lib/api";
+
+type RequestDetail = {
+  id: string;
+};
+
+type FormState = {
+  title: string;
+  featureName: string;
+  contextDescription: string;
+  tone: string;
+  stylePreferences: string;
+  constraintDevice: string;
+  constraintFeatureNorm: string;
+  constraintStyleTag: string;
+  assignedWriterId: string;
+};
+
+const initialFormState: FormState = {
+  title: "",
+  featureName: "",
+  contextDescription: "",
+  tone: "",
+  stylePreferences: "",
+  constraintDevice: "",
+  constraintFeatureNorm: "",
+  constraintStyleTag: "",
+  assignedWriterId: "",
+};
+
+export function NewRequestForm() {
+  const api = useApiClient();
+  const router = useRouter();
+  const [formState, setFormState] = useState<FormState>(initialFormState);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const updateField = (field: keyof FormState) => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setFormState((current) => ({
+      ...current,
+      [field]: event.target.value,
+    }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setErrorMessage(null);
+
+    const title = formState.title.trim();
+    const featureName = formState.featureName.trim();
+
+    if (!title || !featureName) {
+      setErrorMessage("Title and feature name are required.");
+      return;
+    }
+
+    const payload: Record<string, unknown> = {
+      title,
+      feature_name: featureName,
+    };
+
+    if (formState.contextDescription.trim()) {
+      payload.context_description = formState.contextDescription.trim();
+    }
+    if (formState.tone.trim()) {
+      payload.tone = formState.tone.trim();
+    }
+    if (formState.stylePreferences.trim()) {
+      payload.style_preferences = formState.stylePreferences.trim();
+    }
+    if (formState.assignedWriterId.trim()) {
+      payload.assigned_writer_id = formState.assignedWriterId.trim();
+    }
+
+    const constraints: Record<string, string> = {};
+    if (formState.constraintDevice.trim()) {
+      constraints.device = formState.constraintDevice.trim();
+    }
+    if (formState.constraintFeatureNorm.trim()) {
+      constraints.feature_norm = formState.constraintFeatureNorm.trim();
+    }
+    if (formState.constraintStyleTag.trim()) {
+      constraints.style_tag = formState.constraintStyleTag.trim();
+    }
+    if (Object.keys(constraints).length > 0) {
+      payload.constraints = constraints;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const response = await api.post<RequestDetail>("/v1/requests", {
+        body: JSON.stringify(payload),
+      });
+      router.push(`/requests/${response.id}`);
+    } catch (error) {
+      const message = error instanceof ApiError ? error.message : "Failed to create request.";
+      setErrorMessage(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-primary-600">Create Request</p>
+          <h1 className="text-2xl font-semibold text-slate-900">New UX copy request</h1>
+          <p className="text-sm text-slate-600">
+            Provide context for the feature and optionally assign a writer to kick off drafting.
+          </p>
+        </div>
+        <Link href="/requests" className="text-sm text-primary-600 hover:text-primary-500">
+          Back to queue
+        </Link>
+      </header>
+
+      {errorMessage && (
+        <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{errorMessage}</div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-8">
+        <div className="grid gap-6 md:grid-cols-2">
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Title<span className="text-xs font-normal text-slate-500">Required</span>
+            <input
+              type="text"
+              value={formState.title}
+              onChange={updateField("title")}
+              className="rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100"
+              placeholder="Robot vacuum returns"
+              required
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Feature name<span className="text-xs font-normal text-slate-500">Required</span>
+            <input
+              type="text"
+              value={formState.featureName}
+              onChange={updateField("featureName")}
+              className="rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100"
+              placeholder="charging"
+              required
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700 md:col-span-2">
+            Context description
+            <textarea
+              value={formState.contextDescription}
+              onChange={updateField("contextDescription")}
+              className="min-h-[120px] rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100"
+              placeholder="Notify the user that the device is returning to its base."
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Tone
+            <input
+              type="text"
+              value={formState.tone}
+              onChange={updateField("tone")}
+              className="rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100"
+              placeholder="concise"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Style preferences
+            <input
+              type="text"
+              value={formState.stylePreferences}
+              onChange={updateField("stylePreferences")}
+              className="rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100"
+              placeholder="system.action"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Constraint · device
+            <input
+              type="text"
+              value={formState.constraintDevice}
+              onChange={updateField("constraintDevice")}
+              className="rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100"
+              placeholder="robot_vacuum"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Constraint · feature norm
+            <input
+              type="text"
+              value={formState.constraintFeatureNorm}
+              onChange={updateField("constraintFeatureNorm")}
+              className="rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100"
+              placeholder="charging"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Constraint · style tag
+            <input
+              type="text"
+              value={formState.constraintStyleTag}
+              onChange={updateField("constraintStyleTag")}
+              className="rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100"
+              placeholder="concise.system.action"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Assigned writer ID
+            <input
+              type="text"
+              value={formState.assignedWriterId}
+              onChange={updateField("assignedWriterId")}
+              className="rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100"
+              placeholder="writer-1"
+            />
+          </label>
+        </div>
+        <div className="flex items-center justify-end gap-3">
+          <Link
+            href="/requests"
+            className="rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100"
+          >
+            Cancel
+          </Link>
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="rounded-md bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-primary-500 disabled:cursor-not-allowed disabled:bg-primary-300"
+          >
+            {isSubmitting ? "Creating…" : "Create request"}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/frontend/app/requests/new/page.tsx
+++ b/frontend/app/requests/new/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+import { NewRequestForm } from "./NewRequestForm";
+
+export const metadata: Metadata = {
+  title: "New Request · UX Writer Assistant",
+  description: "Capture a new UX copy request and assign it to a writer.",
+};
+
+export default function NewRequestPage() {
+  return <NewRequestForm />;
+}


### PR DESCRIPTION
## Summary
- add a UX request creation form at `/requests/new` that posts to `/v1/requests`
- implement a request detail view with draft, approval, and comment summaries
- provide route metadata so the new pages plug into the existing AppShell navigation

## Testing
- `pnpm lint` *(fails: command prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e6225953488324a731db2a43c63dab